### PR TITLE
Add rule to only test PHP file types

### DIFF
--- a/TI-WPCS/ruleset.xml
+++ b/TI-WPCS/ruleset.xml
@@ -4,11 +4,13 @@
 	<description>Thoughts and Ideas WordPress Coding Standards.</description>
 
 	<config name="testVersion" value="5.2-99.0" />
-	<config name="extensions" value="php" />
 
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 
+	<!-- Only test PHP files. -->
+	<arg name="extensions" value="php" />
+	
 	<!-- Include the WordPress ruleset, with exclusions. -->
 	<rule ref="WordPress">
 	</rule>


### PR DESCRIPTION
We should test other file types in their own language.